### PR TITLE
Update PowerShell target list/comment for Example.4.Hybrid.csproj

### DIFF
--- a/src/Example.4.Hybrid/Example.4.Hybrid.csproj
+++ b/src/Example.4.Hybrid/Example.4.Hybrid.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <AssemblyName>PEUHybrid</AssemblyName>
     <!--
-      This targets PowerShell 7.3+
+      This targets PowerShell 7.2+
       To target others:
-      PowerShell 7.2+: net6.0
+      PowerShell 7.3+: net7.0
       PowerShell 5.1+: netstandard2.0
     -->
     <TargetFramework>net6.0</TargetFramework>


### PR DESCRIPTION
This example was changed to target PowerShell 7.2+, so comment and list references for '7.2+' and '7.3+' need to be swapped.